### PR TITLE
Remove guava dependency duplicated in webapp libs

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.uma.permission.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.oauth.uma.permission.endpoint/pom.xml
@@ -236,6 +236,10 @@
                     <groupId>javax.ws.rs</groupId>
                     <artifactId>jsr311-api</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/components/org.wso2.carbon.identity.oauth.uma.resource.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.oauth.uma.resource.endpoint/pom.xml
@@ -228,6 +228,10 @@
                     <groupId>javax.ws.rs</groupId>
                     <artifactId>jsr311-api</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Proposed changes in this pull request
This is done for the CXF3 dependency upgrade effort. It removes guava jars that get packed unnecessarily inside the lib folder of webapps.