### PR TITLE
Upgrade nimbusds-jose-jwt library

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.uma.grant/pom.xml
+++ b/components/org.wso2.carbon.identity.oauth.uma.grant/pom.xml
@@ -87,8 +87,8 @@
                             org.apache.commons.lang.*,
                             org.apache.oltu.oauth2.common.validators.*,
 
-                            com.nimbusds.jose.*,
-                            com.nimbusds.jwt.*,
+                            com.nimbusds.jose.*; version="${nimbusds.osgi.version.range}",
+                            com.nimbusds.jwt.*; version="${nimbusds.osgi.version.range}",
 
                             org.wso2.carbon.identity.core.util.*;version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.application.authentication.framework.model.*,

--- a/pom.xml
+++ b/pom.xml
@@ -481,6 +481,8 @@
 
         <org.wso2.carbon.database.utils.version.range>[2.0.0,3.0.0)</org.wso2.carbon.database.utils.version.range>
 
+        <nimbusds.version>7.3.0.wso2v1</nimbusds.version>
+        <nimbusds.osgi.version.range>[7.3.0,8.0.0)</nimbusds.osgi.version.range>
     </properties>
 
 </project>


### PR DESCRIPTION
This PR needs to be merged only after wso2/orbit#373 is merged and the nimbusds orbit bundle is released.

Part of wso2/product-is#5786