### PR TITLE
Add java 11 and 17 to PR builder. 

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -17,6 +17,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    strategy:
+          matrix:
+            java-version: [ 11, 17 ]
+            
     steps:
       - uses: actions/checkout@v2
       - name: Set up Adopt JDK 8

--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
           matrix:
-            java-version: [ 11, 17 ]
+            java-version: [ 8, 11, 17 ]
             
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
## Purpose
> Since going forward java 11 or higher versions are supported, the PR builders should run for these java versions as well to avoid use of deprecated APIs. 
