### PR TITLE
Add custom keystore support for uma grant

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.uma.grant/src/main/java/org/wso2/carbon/identity/oauth/uma/grant/UMA2GrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth.uma.grant/src/main/java/org/wso2/carbon/identity/oauth/uma/grant/UMA2GrantHandler.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2018-2025, WSO2 LLC. (http://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -11,7 +11,7 @@
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the
+ * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
  */
@@ -298,7 +298,7 @@ public class UMA2GrantHandler extends AbstractAuthorizationGrantHandler {
     private boolean isEncryptedJWTSigned(String payload) {
 
         if (StringUtils.isNotEmpty(payload)) {
-            String[] parts = payload.split(".");
+            String[] parts = payload.split("\\.");
             return parts.length == 3 && StringUtils.isNotEmpty(parts[2]);
         }
         return false;

--- a/pom.xml
+++ b/pom.xml
@@ -396,7 +396,7 @@
         </org.wso2.carbon.identity.auth.service.version>
 
         <!-- Identity Inbound Auth OAuth Version-->
-        <org.wso2.carbon.identity.oauth.version>7.0.278-SNAPSHOT</org.wso2.carbon.identity.oauth.version>
+        <org.wso2.carbon.identity.oauth.version>7.0.286</org.wso2.carbon.identity.oauth.version>
         <org.wso2.carbon.identity.oauth.import.version.range>[6.2.18, 8.0.0)</org.wso2.carbon.identity.oauth.import.version.range>
 
         <carbon.database.utils.version>2.0.7</carbon.database.utils.version>

--- a/pom.xml
+++ b/pom.xml
@@ -345,7 +345,7 @@
 
         <!-- UMA Version-->
         <identity.oauth.uma.exp.pkg.version>${project.version}</identity.oauth.uma.exp.pkg.version>
-        <identity.oauth.uma.imp.pkg.version.range>[1.1.0,2.0.0)</identity.oauth.uma.imp.pkg.version.range>
+        <identity.oauth.uma.imp.pkg.version.range>[1.1.0,3.0.0)</identity.oauth.uma.imp.pkg.version.range>
 
         <!--Swagger Dependency Version-->
         <com.fasterxml.jackson.version>2.13.2</com.fasterxml.jackson.version>
@@ -395,7 +395,7 @@
         </org.wso2.carbon.identity.auth.service.version>
 
         <!-- Identity Inbound Auth OAuth Version-->
-        <org.wso2.carbon.identity.oauth.version>6.2.18</org.wso2.carbon.identity.oauth.version>
+        <org.wso2.carbon.identity.oauth.version>7.0.278-SNAPSHOT</org.wso2.carbon.identity.oauth.version>
         <org.wso2.carbon.identity.oauth.import.version.range>[6.2.18, 8.0.0)</org.wso2.carbon.identity.oauth.import.version.range>
 
         <carbon.database.utils.version>2.0.7</carbon.database.utils.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1,21 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~ Copyright (c) 2018-2025, WSO2 LLC. (http://www.wso2.com).
   ~
-  ~  WSO2 Inc. licenses this file to you under the Apache License,
-  ~  Version 2.0 (the "License"); you may not use this file except
-  ~  in compliance with the License.
-  ~  You may obtain a copy of the License at
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
   ~
-  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~ http://www.apache.org/licenses/LICENSE-2.0
   ~
-  ~  Unless required by applicable law or agreed to in writing,
-  ~  software distributed under the License is distributed on an
-  ~  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~  KIND, either express or implied.  See the License for the
-  ~  specific language governing permissions and limitations
-  ~  under the License.
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
   -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>


### PR DESCRIPTION
## Purpose
This PR introduces the necessary changes to support configuring a custom keystore for the OAuth protocol. It updates all relevant areas where keystores are used. If a custom keystore is not configured, the system will fall back to the default primary or tenanted keystore.

The main changes include:

- When the `KeyStoreManager` was previously used to resolve keystore keys, it is now replaced with the `IdentityKeyStoreResolver`, which dynamically selects the appropriate keystore—custom, primary, or tenanted.
- Previously, there was an issue in the logic used to check whether the decrypted JWT was signed. The code incorrectly used `String[] parts = payload.split(".");`, which caused unexpected behavior because `.` is a special character in regular expressions. This has been fixed by escaping the dot character properly: `String[] parts = payload.split("\\.");`.

To configure a custom keystore for OAuth, use the following TOML configuration:

```toml
[[keystore.custom]]
file_name = "custom.p12"
password = "password"
type = "PKCS12"
alias = "myOrgCert"
key_password = "password"

[keystore.mapping.oauth]
keystore_file_name = "custom.p12"
use_in_all_tenants = true
```


## Related Issue
- https://github.com/wso2/product-is/issues/20564