### PR TITLE
Bump nimbus-jose-jwt version to 10.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -403,8 +403,8 @@
 
         <org.wso2.carbon.database.utils.version.range>[2.0.0,3.0.0)</org.wso2.carbon.database.utils.version.range>
 
-        <nimbusds.version>7.3.0.wso2v1</nimbusds.version>
-        <nimbusds.osgi.version.range>[7.3.0,8.0.0)</nimbusds.osgi.version.range>
+        <nimbusds.version>10.3.0.wso2v1</nimbusds.version>
+        <nimbusds.osgi.version.range>[10.3.0.wso2v1,11.0.0)</nimbusds.osgi.version.range>
     </properties>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -404,7 +404,7 @@
         <org.wso2.carbon.database.utils.version.range>[2.0.0,3.0.0)</org.wso2.carbon.database.utils.version.range>
 
         <nimbusds.version>10.3.0.wso2v1</nimbusds.version>
-        <nimbusds.osgi.version.range>[10.3.0.wso2v1,11.0.0)</nimbusds.osgi.version.range>
+        <nimbusds.osgi.version.range>[10.3.0,11.0.0)</nimbusds.osgi.version.range>
     </properties>
 
 </project>


### PR DESCRIPTION
### Purpose
> The nimbus library needs to be bumped in the product due. 

### Related Issue/s 
- https://github.com/wso2/product-is/issues/23582