### PR TITLE
Add Java 21 Compile Time Support

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -1,7 +1,7 @@
 # This workflow will build the project on pull requests with tests
 # Uses:
 #   OS: ubuntu-latest
-#   JDK: Adopt JDK 8
+#   JDK: Adopt JDK 21
 
 name: PR Builder
 
@@ -17,16 +17,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    strategy:
-          matrix:
-            java-version: [ 8, 11, 17 ]
-            
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Adopt JDK 8
+      - uses: actions/checkout@v4
+      - name: Set up Adopt JDK 21
         uses: actions/setup-java@v2
         with:
-          java-version: "8"
+          java-version: 21
           distribution: "adopt"
       - name: Cache local Maven repository
         id: cache-maven-m2

--- a/components/org.wso2.carbon.identity.api.server.oauth.uma.permission/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.oauth.uma.permission/pom.xml
@@ -37,10 +37,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
             </plugin>
             <!-- Plugin for generating the swagger server stubs-->
             <!--<plugin>
@@ -250,15 +246,9 @@
             <artifactId>slf4j-api</artifactId>
             <scope>test</scope>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/org.powermock/powermock-module-testng -->
         <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-testng</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito</artifactId>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -286,6 +276,10 @@
                 <exclusion>
                     <groupId>javax.ws.rs</groupId>
                     <artifactId>jsr311-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.ops4j.pax.logging</groupId>
+                    <artifactId>pax-logging-api</artifactId>
                 </exclusion>
             </exclusions>
             <scope>provided</scope>

--- a/components/org.wso2.carbon.identity.api.server.oauth.uma.permission/src/test/java/org/wso2/carbon/identity/oauth/uma/permission/endpoint/PermissionApiServiceImplTest.java
+++ b/components/org.wso2.carbon.identity.api.server.oauth.uma.permission/src/test/java/org/wso2/carbon/identity/oauth/uma/permission/endpoint/PermissionApiServiceImplTest.java
@@ -20,16 +20,15 @@ package org.wso2.carbon.identity.oauth.uma.permission.endpoint;
 
 import org.apache.cxf.jaxrs.ext.MessageContext;
 import org.mockito.Mock;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
 import org.osgi.framework.BundleContext;
 import org.osgi.util.tracker.ServiceTracker;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.testng.PowerMockTestCase;
-import org.testng.IObjectFactory;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.ObjectFactory;
 import org.testng.annotations.Test;
-import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.context.internal.OSGiDataHolder;
 import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.auth.service.AuthenticationContext;
@@ -46,21 +45,17 @@ import org.wso2.carbon.user.core.util.UserCoreUtil;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.Response;
 
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyList;
-import static org.mockito.Matchers.anyString;
-import static org.powermock.api.mockito.PowerMockito.doThrow;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
-import static org.powermock.api.mockito.PowerMockito.when;
-import static org.powermock.api.mockito.PowerMockito.whenNew;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import static org.wso2.carbon.identity.oauth.uma.permission.endpoint.PermissionApiServiceImpl.OAUTH2_ALLOWED_SCOPES;
 import static org.wso2.carbon.identity.oauth.uma.permission.endpoint.PermissionApiServiceImpl.PAT_SCOPE;
 
-@PrepareForTest({BundleContext.class, ServiceTracker.class, PrivilegedCarbonContext.class, PermissionService.class,
-        UserCoreUtil.class})
-public class PermissionApiServiceImplTest extends PowerMockTestCase {
+public class PermissionApiServiceImplTest {
 
     private static final String USERNAME_WITH_USERSTORE_DOMAIN = "PRIMARY/admin";
     private static final String USERNAME = "admin";
@@ -69,9 +64,6 @@ public class PermissionApiServiceImplTest extends PowerMockTestCase {
 
     @Mock
     private BundleContext mockBundleContext;
-
-    @Mock
-    private ServiceTracker mockServiceTracker;
 
     @Mock
     private PermissionService mockPermissionService;
@@ -91,30 +83,32 @@ public class PermissionApiServiceImplTest extends PowerMockTestCase {
     @Mock
     private User mockUser;
 
-    @ObjectFactory
-    public IObjectFactory getObjectFactory() {
-
-        return new org.powermock.modules.testng.PowerMockObjectFactory();
-    }
+    private MockedStatic<UserCoreUtil> mockedUserCoreUtil;
+    private MockedConstruction<ServiceTracker> mockedServiceTrackerConstruction;
 
     @BeforeMethod
     public void setUp() throws Exception {
 
+        MockitoAnnotations.openMocks(this);
         permissionApiService = new PermissionApiServiceImpl();
         resourceModelDTO = new ResourceModelDTO();
-        mockStatic(UserCoreUtil.class);
-        //Get OSGIservice by starting the tenant flow.
-        whenNew(ServiceTracker.class).withAnyArguments().thenReturn(mockServiceTracker);
+        Object[] services = new Object[]{mockPermissionService};
+        mockedServiceTrackerConstruction = Mockito.mockConstruction(ServiceTracker.class,
+                (mock, context) -> when(mock.getServices()).thenReturn(services));
         TestUtil.startTenantFlow("carbon.super");
-        Object[] services = new Object[1];
-        services[0] = mockPermissionService;
-        when(mockServiceTracker.getServices()).thenReturn(services);
         OSGiDataHolder.getInstance().setBundleContext(mockBundleContext);
+        mockedUserCoreUtil = Mockito.mockStatic(UserCoreUtil.class);
     }
 
     @AfterMethod
     public void tearDown() throws Exception {
 
+        if (mockedUserCoreUtil != null) {
+            mockedUserCoreUtil.close();
+        }
+        if (mockedServiceTrackerConstruction != null) {
+            mockedServiceTrackerConstruction.close();
+        }
     }
 
     @Test
@@ -126,7 +120,7 @@ public class PermissionApiServiceImplTest extends PowerMockTestCase {
         when(mockAuthenticationContext.getParameter(anyString())).thenReturn(tokenScopes);
         when(mockAuthenticationContext.getUser()).thenReturn(mockUser);
         when(mockUser.getUserName()).thenReturn(USERNAME_WITH_USERSTORE_DOMAIN);
-        when(UserCoreUtil.removeDomainFromName(anyString())).thenReturn(USERNAME);
+        mockedUserCoreUtil.when(() -> UserCoreUtil.removeDomainFromName(anyString())).thenReturn(USERNAME);
         PermissionTicketModel permissionTicketModel = new PermissionTicketModel();
         when(mockPermissionService.issuePermissionTicket(anyList(), anyInt(), anyString(), anyString(), anyString())).
                 thenReturn(permissionTicketModel);
@@ -144,7 +138,7 @@ public class PermissionApiServiceImplTest extends PowerMockTestCase {
         when(mockAuthenticationContext.getParameter(anyString())).thenReturn(tokenScopes);
         when(mockAuthenticationContext.getUser()).thenReturn(mockUser);
         when(mockUser.getUserName()).thenReturn(USERNAME_WITH_USERSTORE_DOMAIN);
-        when(UserCoreUtil.removeDomainFromName(anyString())).thenReturn(USERNAME);
+        mockedUserCoreUtil.when(() -> UserCoreUtil.removeDomainFromName(anyString())).thenReturn(USERNAME);
         doThrow(new UMAServerException("Server")).when(mockPermissionService).issuePermissionTicket(anyList(),
                 anyInt(), anyString(), anyString(), anyString());
         try {
@@ -163,7 +157,7 @@ public class PermissionApiServiceImplTest extends PowerMockTestCase {
         when(mockAuthenticationContext.getParameter(anyString())).thenReturn(tokenScopes);
         when(mockAuthenticationContext.getUser()).thenReturn(mockUser);
         when(mockUser.getUserName()).thenReturn(USERNAME_WITH_USERSTORE_DOMAIN);
-        when(UserCoreUtil.removeDomainFromName(anyString())).thenReturn(USERNAME);
+        mockedUserCoreUtil.when(() -> UserCoreUtil.removeDomainFromName(anyString())).thenReturn(USERNAME);
         UMAClientException umaClientException = new UMAClientException(UMAConstants
                 .ErrorMessages.ERROR_BAD_REQUEST_INVALID_RESOURCE_ID);
         doThrow(umaClientException).when(mockPermissionService).issuePermissionTicket(anyList(), anyInt(),
@@ -197,7 +191,7 @@ public class PermissionApiServiceImplTest extends PowerMockTestCase {
         when(mockAuthenticationContext.getParameter(anyString())).thenReturn(tokenScopes);
         when(mockAuthenticationContext.getUser()).thenReturn(mockUser);
         when(mockUser.getUserName()).thenReturn(USERNAME_WITH_USERSTORE_DOMAIN);
-        when(UserCoreUtil.removeDomainFromName(anyString())).thenReturn(USERNAME);
+        mockedUserCoreUtil.when(() -> UserCoreUtil.removeDomainFromName(anyString())).thenReturn(USERNAME);
         ResourceModelDTO requestedPermission = null;
         assertEquals(permissionApiService.requestPermission(requestedPermission, mockMessageContext).getStatus(),
                 Response.Status.BAD_REQUEST.getStatusCode());

--- a/components/org.wso2.carbon.identity.api.server.oauth.uma.resource/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.oauth.uma.resource/pom.xml
@@ -36,10 +36,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
             </plugin>
             <!--Plugin for generating the swagger server stubs
             <plugin>
@@ -241,15 +237,9 @@
             <artifactId>slf4j-api</artifactId>
             <scope>test</scope>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/org.powermock/powermock-module-testng -->
         <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-testng</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito</artifactId>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -281,6 +271,10 @@
                 <exclusion>
                     <groupId>javax.ws.rs</groupId>
                     <artifactId>jsr311-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.ops4j.pax.logging</groupId>
+                    <artifactId>pax-logging-api</artifactId>
                 </exclusion>
             </exclusions>
             <scope>provided</scope>

--- a/components/org.wso2.carbon.identity.api.server.oauth.uma.resource/src/test/java/org/wso2/carbon/identity/oauth/uma/resource/endpoint/impl/ResourceRegistrationApiServiceImplExceptionTest.java
+++ b/components/org.wso2.carbon.identity.api.server.oauth.uma.resource/src/test/java/org/wso2/carbon/identity/oauth/uma/resource/endpoint/impl/ResourceRegistrationApiServiceImplExceptionTest.java
@@ -2,15 +2,14 @@ package org.wso2.carbon.identity.oauth.uma.resource.endpoint.impl;
 
 import org.apache.cxf.jaxrs.ext.MessageContext;
 import org.mockito.Mock;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
 import org.osgi.framework.BundleContext;
 import org.osgi.util.tracker.ServiceTracker;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.testng.PowerMockTestCase;
-import org.testng.IObjectFactory;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.ObjectFactory;
 import org.testng.annotations.Test;
-import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.context.internal.OSGiDataHolder;
 import org.wso2.carbon.identity.auth.service.AuthenticationContext;
 import org.wso2.carbon.identity.oauth.uma.common.exception.UMAException;
@@ -27,14 +26,12 @@ import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.Response;
 
-import static org.mockito.Matchers.anyString;
-import static org.powermock.api.mockito.PowerMockito.when;
-import static org.powermock.api.mockito.PowerMockito.whenNew;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertNotEquals;
 
 
-@PrepareForTest({BundleContext.class, ServiceTracker.class, PrivilegedCarbonContext.class, ResourceService.class})
-public class ResourceRegistrationApiServiceImplExceptionTest extends PowerMockTestCase {
+public class ResourceRegistrationApiServiceImplExceptionTest {
 
     private ResourceRegistrationApiServiceImpl resourcesApiService = null;
     private Resource resource;
@@ -47,9 +44,6 @@ public class ResourceRegistrationApiServiceImplExceptionTest extends PowerMockTe
     private BundleContext mockBundleContext;
 
     @Mock
-    private ServiceTracker mockServiceTracker;
-
-    @Mock
     private MessageContext mockMessageContext;
 
     @Mock
@@ -58,23 +52,18 @@ public class ResourceRegistrationApiServiceImplExceptionTest extends PowerMockTe
     @Mock
     private HttpServletRequest mockHTTPServletRequest;
 
-    @ObjectFactory
-    public IObjectFactory getObjectFactory() {
-
-        return new org.powermock.modules.testng.PowerMockObjectFactory();
-    }
+    private MockedConstruction<ServiceTracker> mockedServiceTrackerConstruction;
 
     @BeforeMethod
     public void setUp() throws Exception {
 
+        MockitoAnnotations.openMocks(this);
         resourcesApiService = new ResourceRegistrationApiServiceImpl();
         resource = new Resource();
-        //Get OSGIservice by starting the tenant flow.
-        whenNew(ServiceTracker.class).withAnyArguments().thenReturn(mockServiceTracker);
+        Object[] services = new Object[]{resourceService};
+        mockedServiceTrackerConstruction = Mockito.mockConstruction(ServiceTracker.class,
+                (mock, context) -> when(mock.getServices()).thenReturn(services));
         TestUtil.startTenantFlow("carbon.super");
-        Object[] services = new Object[1];
-        services[0] = resourceService;
-        when(mockServiceTracker.getServices()).thenReturn(services);
         OSGiDataHolder.getInstance().setBundleContext(mockBundleContext);
 
         resource.setName("photo_albem1");
@@ -88,6 +77,13 @@ public class ResourceRegistrationApiServiceImplExceptionTest extends PowerMockTe
         resource.setType("http://www.example.com/rsrcs/photoalbum");
     }
 
+    @AfterMethod
+    public void tearDown() throws Exception {
+
+        if (mockedServiceTrackerConstruction != null) {
+            mockedServiceTrackerConstruction.close();
+        }
+    }
 
     @Test
     public void testUpdateResource() throws Exception {

--- a/components/org.wso2.carbon.identity.api.server.oauth.uma.resource/src/test/java/org/wso2/carbon/identity/oauth/uma/resource/endpoint/impl/ResourceRegistrationApiServiceImplTest.java
+++ b/components/org.wso2.carbon.identity.api.server.oauth.uma.resource/src/test/java/org/wso2/carbon/identity/oauth/uma/resource/endpoint/impl/ResourceRegistrationApiServiceImplTest.java
@@ -17,15 +17,14 @@ package org.wso2.carbon.identity.oauth.uma.resource.endpoint.impl;
 
 import org.apache.cxf.jaxrs.ext.MessageContext;
 import org.mockito.Mock;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
 import org.osgi.framework.BundleContext;
 import org.osgi.util.tracker.ServiceTracker;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.testng.PowerMockTestCase;
-import org.testng.IObjectFactory;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.ObjectFactory;
 import org.testng.annotations.Test;
-import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.context.internal.OSGiDataHolder;
 import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.auth.service.AuthenticationContext;
@@ -39,14 +38,12 @@ import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.Response;
 
-import static org.mockito.Matchers.anyString;
-import static org.powermock.api.mockito.PowerMockito.when;
-import static org.powermock.api.mockito.PowerMockito.whenNew;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
 
-@PrepareForTest({BundleContext.class, ServiceTracker.class, PrivilegedCarbonContext.class, ResourceService.class})
-public class ResourceRegistrationApiServiceImplTest extends PowerMockTestCase {
+public class ResourceRegistrationApiServiceImplTest {
 
     private ResourceRegistrationApiServiceImpl resourcesApiService = null;
     private Resource resource;
@@ -59,9 +56,6 @@ public class ResourceRegistrationApiServiceImplTest extends PowerMockTestCase {
     private BundleContext mockBundleContext;
 
     @Mock
-    private ServiceTracker mockServiceTracker;
-
-    @Mock
     private MessageContext mockMessageContext;
 
     @Mock
@@ -70,26 +64,18 @@ public class ResourceRegistrationApiServiceImplTest extends PowerMockTestCase {
     @Mock
     private HttpServletRequest mockHTTPServletRequest;
 
-    @ObjectFactory
-    public IObjectFactory getObjectFactory() {
-
-        return new org.powermock.modules.testng.PowerMockObjectFactory();
-    }
+    private MockedConstruction<ServiceTracker> mockedServiceTrackerConstruction;
 
     @BeforeMethod
     public void setUp() throws Exception {
 
+        MockitoAnnotations.openMocks(this);
         resourcesApiService = new ResourceRegistrationApiServiceImpl();
         resource = new Resource();
-
-        resourcesApiService = new ResourceRegistrationApiServiceImpl();
-        resource = new Resource();
-        //Get OSGIservice by starting the tenant flow.
-        whenNew(ServiceTracker.class).withAnyArguments().thenReturn(mockServiceTracker);
+        Object[] services = new Object[]{resourceService};
+        mockedServiceTrackerConstruction = Mockito.mockConstruction(ServiceTracker.class,
+                (mock, context) -> when(mock.getServices()).thenReturn(services));
         TestUtil.startTenantFlow("carbon.super");
-        Object[] services = new Object[1];
-        services[0] = resourceService;
-        when(mockServiceTracker.getServices()).thenReturn(services);
         OSGiDataHolder.getInstance().setBundleContext(mockBundleContext);
 
         resource.setName("photo_albem");
@@ -101,6 +87,14 @@ public class ResourceRegistrationApiServiceImplTest extends PowerMockTestCase {
         resource.setIconUri("http://www.example.com/icons/sky.png");
         resource.setDescription("Collection of digital photographs");
         resource.setType("http://www.example.com/rsrcs/photoalbum");
+    }
+
+    @AfterMethod
+    public void tearDown() throws Exception {
+
+        if (mockedServiceTrackerConstruction != null) {
+            mockedServiceTrackerConstruction.close();
+        }
     }
 
     @Test

--- a/components/org.wso2.carbon.identity.api.server.oauth.uma.resource/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.api.server.oauth.uma.resource/src/test/resources/testng.xml
@@ -17,8 +17,7 @@
 
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
 
-<suite name="Identity-Oauth-Uma-Endpoint-Test-Suite"
-       object-factory="org.powermock.modules.testng.PowerMockObjectFactory">
+<suite name="Identity-Oauth-Uma-Endpoint-Test-Suite">
     <test name="Util-Tests" preserve-order="true" parallel="false">
         <classes>
             <class name="org.wso2.carbon.identity.oauth.uma.resource.endpoint.impl.ResourceRegistrationApiServiceImplTest" />

--- a/components/org.wso2.carbon.identity.oauth.uma.grant/pom.xml
+++ b/components/org.wso2.carbon.identity.oauth.uma.grant/pom.xml
@@ -121,13 +121,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-testng</artifactId>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/components/org.wso2.carbon.identity.oauth.uma.permission.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.oauth.uma.permission.endpoint/pom.xml
@@ -34,15 +34,11 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.2</version>
+                <version>3.3.2</version>
                 <configuration>
                     <webResources>
                         <resource>

--- a/components/org.wso2.carbon.identity.oauth.uma.permission.service/pom.xml
+++ b/components/org.wso2.carbon.identity.oauth.uma.permission.service/pom.xml
@@ -34,10 +34,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.felix</groupId>
@@ -190,15 +186,9 @@
             <artifactId>slf4j-api</artifactId>
             <scope>test</scope>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/org.powermock/powermock-module-testng -->
         <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-testng</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito</artifactId>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/components/org.wso2.carbon.identity.oauth.uma.permission.service/src/test/java/org/wso2/carbon/identity/oauth/uma/permission/service/dao/PermissionTicketDAOTest.java
+++ b/components/org.wso2.carbon.identity.oauth.uma.permission.service/src/test/java/org/wso2/carbon/identity/oauth/uma/permission/service/dao/PermissionTicketDAOTest.java
@@ -18,12 +18,10 @@
 
 package org.wso2.carbon.identity.oauth.uma.permission.service.dao;
 
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.testng.PowerMockTestCase;
-import org.testng.IObjectFactory;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
-import org.testng.annotations.ObjectFactory;
 import org.testng.annotations.Test;
 import org.wso2.carbon.database.utils.jdbc.NamedJdbcTemplate;
 import org.wso2.carbon.identity.oauth.uma.common.JdbcUtils;
@@ -40,15 +38,10 @@ import java.util.List;
 import java.util.UUID;
 import javax.sql.DataSource;
 
-import static org.powermock.api.mockito.PowerMockito.mock;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
-import static org.powermock.api.mockito.PowerMockito.when;
-
 /**
  * Unit tests for PermissionTicketDAO.
  */
-@PrepareForTest(JdbcUtils.class)
-public class PermissionTicketDAOTest extends PowerMockTestCase {
+public class PermissionTicketDAOTest {
 
     private static final String DB_NAME = "UMA_DB";
     private Timestamp createdTime = new Timestamp(System.currentTimeMillis());
@@ -74,27 +67,21 @@ public class PermissionTicketDAOTest extends PowerMockTestCase {
         DAOTestUtils.closeH2Base(DB_NAME);
     }
 
-    @ObjectFactory
-    public IObjectFactory getObjectFactory() {
-
-        return new org.powermock.modules.testng.PowerMockObjectFactory();
-    }
-
     @Test
     public void testPersistPermissionTicket() throws Exception {
 
-        DataSource dataSource = mock(DataSource.class);
-        mockStatic(JdbcUtils.class);
-        when(JdbcUtils.getNewNamedTemplate()).thenReturn(new NamedJdbcTemplate(dataSource));
-        try (Connection connection = DAOTestUtils.getConnection(DB_NAME)) {
-            Connection spy = DAOTestUtils.spyConnection(connection);
-            when(dataSource.getConnection()).thenReturn(spy);
-            List<Resource> list = new ArrayList<>();
-            list.add(getResource());
-            PermissionTicketDAO.persistPermissionTicket(list, getPermissionTicketDO(),
-                    TestConstants.RESOURCE_OWNER_NAME, TestConstants.CLIENT_ID, TestConstants.USER_DOMAIN);
+        DataSource dataSource = Mockito.mock(DataSource.class);
+        try (MockedStatic<JdbcUtils> mockedJdbcUtils = Mockito.mockStatic(JdbcUtils.class)) {
+            mockedJdbcUtils.when(JdbcUtils::getNewNamedTemplate).thenReturn(new NamedJdbcTemplate(dataSource));
+            try (Connection connection = DAOTestUtils.getConnection(DB_NAME)) {
+                Connection spy = DAOTestUtils.spyConnection(connection);
+                Mockito.when(dataSource.getConnection()).thenReturn(spy);
+                List<Resource> list = new ArrayList<>();
+                list.add(getResource());
+                PermissionTicketDAO.persistPermissionTicket(list, getPermissionTicketDO(),
+                        TestConstants.RESOURCE_OWNER_NAME, TestConstants.CLIENT_ID, TestConstants.USER_DOMAIN);
+            }
         }
-
     }
 
     /**
@@ -103,16 +90,17 @@ public class PermissionTicketDAOTest extends PowerMockTestCase {
     @Test(expectedExceptions = UMAException.class)
     public void testPersistInvalidResourceId() throws Exception {
 
-        DataSource dataSource = mock(DataSource.class);
-        mockStatic(JdbcUtils.class);
-        when(JdbcUtils.getNewNamedTemplate()).thenReturn(new NamedJdbcTemplate(dataSource));
-        try (Connection connection = DAOTestUtils.getConnection(DB_NAME)) {
-            Connection spy = DAOTestUtils.spyConnection(connection);
-            when(dataSource.getConnection()).thenReturn(spy);
-            List<Resource> list = new ArrayList<>();
-            list.add(getResourceWithInvalidResourceId());
-            PermissionTicketDAO.persistPermissionTicket(list, getPermissionTicketDO(),
-                    TestConstants.RESOURCE_OWNER_NAME, TestConstants.CLIENT_ID, TestConstants.USER_DOMAIN);
+        DataSource dataSource = Mockito.mock(DataSource.class);
+        try (MockedStatic<JdbcUtils> mockedJdbcUtils = Mockito.mockStatic(JdbcUtils.class)) {
+            mockedJdbcUtils.when(JdbcUtils::getNewNamedTemplate).thenReturn(new NamedJdbcTemplate(dataSource));
+            try (Connection connection = DAOTestUtils.getConnection(DB_NAME)) {
+                Connection spy = DAOTestUtils.spyConnection(connection);
+                Mockito.when(dataSource.getConnection()).thenReturn(spy);
+                List<Resource> list = new ArrayList<>();
+                list.add(getResourceWithInvalidResourceId());
+                PermissionTicketDAO.persistPermissionTicket(list, getPermissionTicketDO(),
+                        TestConstants.RESOURCE_OWNER_NAME, TestConstants.CLIENT_ID, TestConstants.USER_DOMAIN);
+            }
         }
     }
 
@@ -122,16 +110,17 @@ public class PermissionTicketDAOTest extends PowerMockTestCase {
     @Test(expectedExceptions = UMAException.class)
     public void testPersistInvalidResourceScope() throws Exception {
 
-        DataSource dataSource = mock(DataSource.class);
-        mockStatic(JdbcUtils.class);
-        when(JdbcUtils.getNewNamedTemplate()).thenReturn(new NamedJdbcTemplate(dataSource));
-        try (Connection connection = DAOTestUtils.getConnection(DB_NAME)) {
-            Connection spy = DAOTestUtils.spyConnection(connection);
-            when(dataSource.getConnection()).thenReturn(spy);
-            List<Resource> list = new ArrayList<>();
-            list.add(getResourceWithInvalidResourceScope());
-            PermissionTicketDAO.persistPermissionTicket(list, getPermissionTicketDO(),
-                    TestConstants.RESOURCE_OWNER_NAME, TestConstants.CLIENT_ID, TestConstants.USER_DOMAIN);
+        DataSource dataSource = Mockito.mock(DataSource.class);
+        try (MockedStatic<JdbcUtils> mockedJdbcUtils = Mockito.mockStatic(JdbcUtils.class)) {
+            mockedJdbcUtils.when(JdbcUtils::getNewNamedTemplate).thenReturn(new NamedJdbcTemplate(dataSource));
+            try (Connection connection = DAOTestUtils.getConnection(DB_NAME)) {
+                Connection spy = DAOTestUtils.spyConnection(connection);
+                Mockito.when(dataSource.getConnection()).thenReturn(spy);
+                List<Resource> list = new ArrayList<>();
+                list.add(getResourceWithInvalidResourceScope());
+                PermissionTicketDAO.persistPermissionTicket(list, getPermissionTicketDO(),
+                        TestConstants.RESOURCE_OWNER_NAME, TestConstants.CLIENT_ID, TestConstants.USER_DOMAIN);
+            }
         }
     }
 

--- a/components/org.wso2.carbon.identity.oauth.uma.permission.service/src/test/java/org/wso2/carbon/identity/oauth/uma/permission/service/impl/PermissionServiceImplTest.java
+++ b/components/org.wso2.carbon.identity.oauth.uma.permission.service/src/test/java/org/wso2/carbon/identity/oauth/uma/permission/service/impl/PermissionServiceImplTest.java
@@ -18,12 +18,10 @@
 
 package org.wso2.carbon.identity.oauth.uma.permission.service.impl;
 
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.testng.IObjectFactory;
+import org.mockito.MockedStatic;
+import org.mockito.MockitoAnnotations;
 import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.ObjectFactory;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth.uma.permission.service.TestConstants;
@@ -32,14 +30,12 @@ import org.wso2.carbon.identity.oauth.uma.permission.service.model.Resource;
 
 import java.util.ArrayList;
 
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
-import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertNotNull;
 
-@PrepareForTest({PermissionTicketDAO.class, OAuthServerConfiguration.class})
 public class PermissionServiceImplTest {
 
-    @InjectMocks
     private PermissionServiceImpl permissionService;
 
     @Mock
@@ -48,25 +44,21 @@ public class PermissionServiceImplTest {
     @BeforeMethod
     public void setUp() throws Exception {
 
+        MockitoAnnotations.openMocks(this);
         permissionService = new PermissionServiceImpl();
-    }
-
-    @ObjectFactory
-    public IObjectFactory getObjectFactory() {
-
-        return new org.powermock.modules.testng.PowerMockObjectFactory();
     }
 
     @Test
     public void testIssuePermissionTicket() throws Exception {
 
-        mockStatic(OAuthServerConfiguration.class);
-        when(OAuthServerConfiguration.getInstance()).thenReturn(oAuthServerConfiguration);
-        when(oAuthServerConfiguration.getAuthorizationCodeValidityPeriodInSeconds()).thenReturn(300L);
-        mockStatic(PermissionTicketDAO.class);
-        assertNotNull(permissionService.issuePermissionTicket(new ArrayList<Resource>(), TestConstants.TENANT_ID,
-                TestConstants.RESOURCE_OWNER_NAME, TestConstants.CLIENT_ID, TestConstants.USER_DOMAIN),
-                "Expected a not null object");
+        try (MockedStatic<OAuthServerConfiguration> mockedOAuthConfig = mockStatic(OAuthServerConfiguration.class);
+             MockedStatic<PermissionTicketDAO> mockedPermissionTicketDAO = mockStatic(PermissionTicketDAO.class)) {
+            mockedOAuthConfig.when(OAuthServerConfiguration::getInstance).thenReturn(oAuthServerConfiguration);
+            when(oAuthServerConfiguration.getAuthorizationCodeValidityPeriodInSeconds()).thenReturn(300L);
+            assertNotNull(permissionService.issuePermissionTicket(new ArrayList<Resource>(), TestConstants.TENANT_ID,
+                    TestConstants.RESOURCE_OWNER_NAME, TestConstants.CLIENT_ID, TestConstants.USER_DOMAIN),
+                    "Expected a not null object");
+        }
     }
 
 }

--- a/components/org.wso2.carbon.identity.oauth.uma.permission.service/src/test/java/org/wso2/carbon/identity/oauth/uma/permission/service/internal/PermissionServiceComponentTest.java
+++ b/components/org.wso2.carbon.identity.oauth.uma.permission.service/src/test/java/org/wso2/carbon/identity/oauth/uma/permission/service/internal/PermissionServiceComponentTest.java
@@ -22,19 +22,15 @@ import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.osgi.framework.BundleContext;
-import org.testng.IObjectFactory;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
-import org.testng.annotations.ObjectFactory;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.oauth.uma.permission.service.impl.PermissionServiceImpl;
 
-import java.util.Dictionary;
-
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.MockitoAnnotations.initMocks;
-import static org.powermock.api.mockito.PowerMockito.doAnswer;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.MockitoAnnotations.openMocks;
 import static org.testng.Assert.assertEquals;
 
 public class PermissionServiceComponentTest {
@@ -45,18 +41,12 @@ public class PermissionServiceComponentTest {
     @BeforeClass
     public void setUp() throws Exception {
 
-        initMocks(this);
+        openMocks(this);
     }
 
     @AfterMethod
     public void tearDown() throws Exception {
 
-    }
-
-    @ObjectFactory
-    public IObjectFactory getObjectFactory() {
-
-        return new org.powermock.modules.testng.PowerMockObjectFactory();
     }
 
     @Test
@@ -71,8 +61,7 @@ public class PermissionServiceComponentTest {
                 serviceName[0] = permissionService.getClass().getName();
                 return null;
             }
-        }).when(bundleContext).registerService(anyString(), any(PermissionServiceComponent.class),
-                any(Dictionary.class));
+        }).when(bundleContext).registerService(anyString(), any(), any());
 
         PermissionServiceComponent permissionServiceComponent = new PermissionServiceComponent();
         permissionServiceComponent.activate(bundleContext);

--- a/components/org.wso2.carbon.identity.oauth.uma.resource.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.oauth.uma.resource.endpoint/pom.xml
@@ -33,15 +33,11 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.2</version>
+                <version>3.3.2</version>
                 <configuration>
                     <webResources>
                         <resource>

--- a/components/org.wso2.carbon.identity.oauth.uma.resource.service/pom.xml
+++ b/components/org.wso2.carbon.identity.oauth.uma.resource.service/pom.xml
@@ -58,10 +58,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.felix</groupId>
@@ -175,13 +171,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-testng</artifactId>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/components/org.wso2.carbon.identity.oauth.uma.resource.service/src/test/java/org/wso2/carbon/identity/oauth/uma/resource/service/dao/ResourceDAOTest.java
+++ b/components/org.wso2.carbon.identity.oauth.uma.resource.service/src/test/java/org/wso2/carbon/identity/oauth/uma/resource/service/dao/ResourceDAOTest.java
@@ -16,12 +16,10 @@
 
 package org.wso2.carbon.identity.oauth.uma.resource.service.dao;
 
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.testng.PowerMockTestCase;
-import org.testng.IObjectFactory;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
-import org.testng.annotations.ObjectFactory;
 import org.testng.annotations.Test;
 import org.wso2.carbon.database.utils.jdbc.NamedJdbcTemplate;
 import org.wso2.carbon.identity.oauth.uma.common.JdbcUtils;
@@ -33,13 +31,8 @@ import java.sql.Connection;
 import java.sql.Timestamp;
 import javax.sql.DataSource;
 
-import static org.powermock.api.mockito.PowerMockito.mock;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
-import static org.powermock.api.mockito.PowerMockito.when;
 
-
-@PrepareForTest(JdbcUtils.class)
-public class ResourceDAOTest extends PowerMockTestCase {
+public class ResourceDAOTest {
 
     private static final String DB_NAME = "regdb";
     private int tenantId = -1234;
@@ -66,36 +59,31 @@ public class ResourceDAOTest extends PowerMockTestCase {
         DAOUtils.closeH2Base(DB_NAME);
     }
 
-    @ObjectFactory
-    public IObjectFactory getObjectFactory() {
-
-        return new org.powermock.modules.testng.PowerMockObjectFactory();
-    }
-
     @Test
     public void testRegisterResource() throws Exception {
 
-        DataSource dataSource = mock(DataSource.class);
-        mockStatic(JdbcUtils.class);
-        when(JdbcUtils.getNewNamedTemplate()).thenReturn(new NamedJdbcTemplate(dataSource));
-        try (Connection connection = DAOUtils.getConnection(DB_NAME)) {
-            Connection spy = DAOUtils.spyConnection(connection);
-            when(dataSource.getConnection()).thenReturn(spy);
-            ResourceDAO.registerResource(new Resource(), resourceOwnerName, tenantId, clientId, userDomain);
+        DataSource dataSource = Mockito.mock(DataSource.class);
+        try (MockedStatic<JdbcUtils> mockedJdbcUtils = Mockito.mockStatic(JdbcUtils.class)) {
+            mockedJdbcUtils.when(JdbcUtils::getNewNamedTemplate).thenReturn(new NamedJdbcTemplate(dataSource));
+            try (Connection connection = DAOUtils.getConnection(DB_NAME)) {
+                Connection spy = DAOUtils.spyConnection(connection);
+                Mockito.when(dataSource.getConnection()).thenReturn(spy);
+                ResourceDAO.registerResource(new Resource(), resourceOwnerName, tenantId, clientId, userDomain);
+            }
         }
-
     }
 
     @Test(priority = 1)
     public void testRetrieveResource() throws Exception {
 
-        DataSource dataSource = mock(DataSource.class);
-        mockStatic(JdbcUtils.class);
-        when(JdbcUtils.getNewNamedTemplate()).thenReturn(new NamedJdbcTemplate(dataSource));
-        try (Connection connection = DAOUtils.getConnection(DB_NAME)) {
-            Connection spy = DAOUtils.spyConnection(connection);
-            when(dataSource.getConnection()).thenReturn(spy);
-            ResourceDAO.retrieveResource(resourceId);
+        DataSource dataSource = Mockito.mock(DataSource.class);
+        try (MockedStatic<JdbcUtils> mockedJdbcUtils = Mockito.mockStatic(JdbcUtils.class)) {
+            mockedJdbcUtils.when(JdbcUtils::getNewNamedTemplate).thenReturn(new NamedJdbcTemplate(dataSource));
+            try (Connection connection = DAOUtils.getConnection(DB_NAME)) {
+                Connection spy = DAOUtils.spyConnection(connection);
+                Mockito.when(dataSource.getConnection()).thenReturn(spy);
+                ResourceDAO.retrieveResource(resourceId);
+            }
         }
     }
 
@@ -105,39 +93,42 @@ public class ResourceDAOTest extends PowerMockTestCase {
     @Test(expectedExceptions = UMAException.class)
     public void testRetrieveResourceWithInvalidResourceId() throws Exception {
 
-        DataSource dataSource = mock(DataSource.class);
-        mockStatic(JdbcUtils.class);
-        when(JdbcUtils.getNewNamedTemplate()).thenReturn(new NamedJdbcTemplate(dataSource));
-        try (Connection connection = DAOUtils.getConnection(DB_NAME)) {
-            Connection spy = DAOUtils.spyConnection(connection);
-            when(dataSource.getConnection()).thenReturn(spy);
-            ResourceDAO.retrieveResource("1234");
+        DataSource dataSource = Mockito.mock(DataSource.class);
+        try (MockedStatic<JdbcUtils> mockedJdbcUtils = Mockito.mockStatic(JdbcUtils.class)) {
+            mockedJdbcUtils.when(JdbcUtils::getNewNamedTemplate).thenReturn(new NamedJdbcTemplate(dataSource));
+            try (Connection connection = DAOUtils.getConnection(DB_NAME)) {
+                Connection spy = DAOUtils.spyConnection(connection);
+                Mockito.when(dataSource.getConnection()).thenReturn(spy);
+                ResourceDAO.retrieveResource("1234");
+            }
         }
     }
 
     @Test
     public void testRetrieveResourceIDs() throws Exception {
 
-        DataSource dataSource = mock(DataSource.class);
-        mockStatic(JdbcUtils.class);
-        when(JdbcUtils.getNewNamedTemplate()).thenReturn(new NamedJdbcTemplate(dataSource));
-        try (Connection connection = DAOUtils.getConnection(DB_NAME)) {
-            Connection spy = DAOUtils.spyConnection(connection);
-            when(dataSource.getConnection()).thenReturn(spy);
-            ResourceDAO.retrieveResourceIDs(resourceOwnerName, userDomain, clientId);
+        DataSource dataSource = Mockito.mock(DataSource.class);
+        try (MockedStatic<JdbcUtils> mockedJdbcUtils = Mockito.mockStatic(JdbcUtils.class)) {
+            mockedJdbcUtils.when(JdbcUtils::getNewNamedTemplate).thenReturn(new NamedJdbcTemplate(dataSource));
+            try (Connection connection = DAOUtils.getConnection(DB_NAME)) {
+                Connection spy = DAOUtils.spyConnection(connection);
+                Mockito.when(dataSource.getConnection()).thenReturn(spy);
+                ResourceDAO.retrieveResourceIDs(resourceOwnerName, userDomain, clientId);
+            }
         }
     }
 
     @Test(priority = 3)
     public void testDeleteResource() throws Exception {
 
-        DataSource dataSource = mock(DataSource.class);
-        mockStatic(JdbcUtils.class);
-        when(JdbcUtils.getNewNamedTemplate()).thenReturn(new NamedJdbcTemplate(dataSource));
-        try (Connection connection = DAOUtils.getConnection(DB_NAME)) {
-            Connection spy = DAOUtils.spyConnection(connection);
-            when(dataSource.getConnection()).thenReturn(spy);
-            ResourceDAO.deleteResource(resourceId);
+        DataSource dataSource = Mockito.mock(DataSource.class);
+        try (MockedStatic<JdbcUtils> mockedJdbcUtils = Mockito.mockStatic(JdbcUtils.class)) {
+            mockedJdbcUtils.when(JdbcUtils::getNewNamedTemplate).thenReturn(new NamedJdbcTemplate(dataSource));
+            try (Connection connection = DAOUtils.getConnection(DB_NAME)) {
+                Connection spy = DAOUtils.spyConnection(connection);
+                Mockito.when(dataSource.getConnection()).thenReturn(spy);
+                ResourceDAO.deleteResource(resourceId);
+            }
         }
     }
 
@@ -147,26 +138,28 @@ public class ResourceDAOTest extends PowerMockTestCase {
     @Test(expectedExceptions = UMAException.class)
     public void testDeleteResourceWithInvalidResourceId() throws Exception {
 
-        DataSource dataSource = mock(DataSource.class);
-        mockStatic(JdbcUtils.class);
-        when(JdbcUtils.getNewNamedTemplate()).thenReturn(new NamedJdbcTemplate(dataSource));
-        try (Connection connection = DAOUtils.getConnection(DB_NAME)) {
-            Connection spy = DAOUtils.spyConnection(connection);
-            when(dataSource.getConnection()).thenReturn(spy);
-            ResourceDAO.deleteResource("1234");
+        DataSource dataSource = Mockito.mock(DataSource.class);
+        try (MockedStatic<JdbcUtils> mockedJdbcUtils = Mockito.mockStatic(JdbcUtils.class)) {
+            mockedJdbcUtils.when(JdbcUtils::getNewNamedTemplate).thenReturn(new NamedJdbcTemplate(dataSource));
+            try (Connection connection = DAOUtils.getConnection(DB_NAME)) {
+                Connection spy = DAOUtils.spyConnection(connection);
+                Mockito.when(dataSource.getConnection()).thenReturn(spy);
+                ResourceDAO.deleteResource("1234");
+            }
         }
     }
 
     @Test(priority = 2)
     public void testUpdateResource() throws Exception {
 
-        DataSource dataSource = mock(DataSource.class);
-        mockStatic(JdbcUtils.class);
-        when(JdbcUtils.getNewNamedTemplate()).thenReturn(new NamedJdbcTemplate(dataSource));
-        try (Connection connection = DAOUtils.getConnection(DB_NAME)) {
-            Connection spy = DAOUtils.spyConnection(connection);
-            when(dataSource.getConnection()).thenReturn(spy);
-            ResourceDAO.updateResource(resourceId, new Resource());
+        DataSource dataSource = Mockito.mock(DataSource.class);
+        try (MockedStatic<JdbcUtils> mockedJdbcUtils = Mockito.mockStatic(JdbcUtils.class)) {
+            mockedJdbcUtils.when(JdbcUtils::getNewNamedTemplate).thenReturn(new NamedJdbcTemplate(dataSource));
+            try (Connection connection = DAOUtils.getConnection(DB_NAME)) {
+                Connection spy = DAOUtils.spyConnection(connection);
+                Mockito.when(dataSource.getConnection()).thenReturn(spy);
+                ResourceDAO.updateResource(resourceId, new Resource());
+            }
         }
     }
 
@@ -176,13 +169,14 @@ public class ResourceDAOTest extends PowerMockTestCase {
     @Test(expectedExceptions = UMAException.class)
     public void testUpdateResourceWithInvalidResourceId() throws Exception {
 
-        DataSource dataSource = mock(DataSource.class);
-        mockStatic(JdbcUtils.class);
-        when(JdbcUtils.getNewNamedTemplate()).thenReturn(new NamedJdbcTemplate(dataSource));
-        try (Connection connection = DAOUtils.getConnection(DB_NAME)) {
-            Connection spy = DAOUtils.spyConnection(connection);
-            when(dataSource.getConnection()).thenReturn(spy);
-            ResourceDAO.updateResource("1234", new Resource());
+        DataSource dataSource = Mockito.mock(DataSource.class);
+        try (MockedStatic<JdbcUtils> mockedJdbcUtils = Mockito.mockStatic(JdbcUtils.class)) {
+            mockedJdbcUtils.when(JdbcUtils::getNewNamedTemplate).thenReturn(new NamedJdbcTemplate(dataSource));
+            try (Connection connection = DAOUtils.getConnection(DB_NAME)) {
+                Connection spy = DAOUtils.spyConnection(connection);
+                Mockito.when(dataSource.getConnection()).thenReturn(spy);
+                ResourceDAO.updateResource("1234", new Resource());
+            }
         }
     }
 

--- a/components/org.wso2.carbon.identity.oauth.uma.resource.service/src/test/java/org/wso2/carbon/identity/oauth/uma/resource/service/impl/ResourceServiceImplTest.java
+++ b/components/org.wso2.carbon.identity.oauth.uma.resource.service/src/test/java/org/wso2/carbon/identity/oauth/uma/resource/service/impl/ResourceServiceImplTest.java
@@ -16,20 +16,17 @@
 
 package org.wso2.carbon.identity.oauth.uma.resource.service.impl;
 
-import org.mockito.InjectMocks;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.testng.IObjectFactory;
+import org.mockito.MockedStatic;
+import org.mockito.MockitoAnnotations;
 import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.ObjectFactory;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.oauth.uma.resource.service.dao.ResourceDAO;
 import org.wso2.carbon.identity.oauth.uma.resource.service.model.Resource;
 
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.mockito.Mockito.mockStatic;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 
-@PrepareForTest({ResourceDAO.class})
 public class ResourceServiceImplTest {
 
     private static final String RESOURCE_ID = "123454-62552-31456";
@@ -39,54 +36,53 @@ public class ResourceServiceImplTest {
     private static final String USERSTORE_DOMAIN = "primary";
     private static Resource resource = new Resource();
 
-    @InjectMocks
     private ResourceServiceImpl resourceService;
 
     @BeforeMethod
     public void setUp() throws Exception {
 
+        MockitoAnnotations.openMocks(this);
         resourceService = new ResourceServiceImpl();
-    }
-
-    @ObjectFactory
-    public IObjectFactory getObjectFactory() {
-
-        return new org.powermock.modules.testng.PowerMockObjectFactory();
     }
 
     @Test
     public void testRegisterResource() throws Exception {
 
-        mockStatic(ResourceDAO.class);
-        assertNull(resourceService.registerResource(resource, RESOURCE_OWNER_NAME, TENANT_ID, CLIENT_ID,
-                USERSTORE_DOMAIN));
+        try (MockedStatic<ResourceDAO> mockedResourceDAO = mockStatic(ResourceDAO.class)) {
+            assertNull(resourceService.registerResource(resource, RESOURCE_OWNER_NAME, TENANT_ID, CLIENT_ID,
+                    USERSTORE_DOMAIN));
+        }
     }
 
     @Test
     public void testGetResourceIds() throws Exception {
 
-        mockStatic(ResourceDAO.class);
-        assertNotNull(resourceService.getResourceIds(RESOURCE_OWNER_NAME, USERSTORE_DOMAIN, CLIENT_ID));
+        try (MockedStatic<ResourceDAO> mockedResourceDAO = mockStatic(ResourceDAO.class)) {
+            assertNotNull(resourceService.getResourceIds(RESOURCE_OWNER_NAME, USERSTORE_DOMAIN, CLIENT_ID));
+        }
     }
 
     @Test
     public void testGetResourceById() throws Exception {
 
-        mockStatic(ResourceDAO.class);
-        assertNull(resourceService.getResourceById(RESOURCE_ID));
+        try (MockedStatic<ResourceDAO> mockedResourceDAO = mockStatic(ResourceDAO.class)) {
+            assertNull(resourceService.getResourceById(RESOURCE_ID));
+        }
     }
 
     @Test
     public void testUpdateResource() throws Exception {
 
-        mockStatic(ResourceDAO.class);
-        assertNotNull(resourceService.updateResource(RESOURCE_ID, resource));
+        try (MockedStatic<ResourceDAO> mockedResourceDAO = mockStatic(ResourceDAO.class)) {
+            assertNotNull(resourceService.updateResource(RESOURCE_ID, resource));
+        }
     }
 
     @Test
     public void testDeleteResource() throws Exception {
 
-        mockStatic(ResourceDAO.class);
-        assertNotNull(resourceService.deleteResource(""));
+        try (MockedStatic<ResourceDAO> mockedResourceDAO = mockStatic(ResourceDAO.class)) {
+            assertNotNull(resourceService.deleteResource(""));
+        }
     }
 }

--- a/components/org.wso2.carbon.identity.oauth.uma.resource.service/src/test/java/org/wso2/carbon/identity/oauth/uma/resource/service/internal/RegisterServiceComponentsTest.java
+++ b/components/org.wso2.carbon.identity.oauth.uma.resource.service/src/test/java/org/wso2/carbon/identity/oauth/uma/resource/service/internal/RegisterServiceComponentsTest.java
@@ -21,19 +21,15 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import org.osgi.framework.BundleContext;
-import org.testng.IObjectFactory;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
-import org.testng.annotations.ObjectFactory;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.oauth.uma.resource.service.impl.ResourceServiceImpl;
 
-import java.util.Dictionary;
-
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.MockitoAnnotations.initMocks;
-import static org.powermock.api.mockito.PowerMockito.doAnswer;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.MockitoAnnotations.openMocks;
 import static org.testng.Assert.assertEquals;
 
 public class RegisterServiceComponentsTest {
@@ -44,18 +40,12 @@ public class RegisterServiceComponentsTest {
     @BeforeClass
     public void setUp() throws Exception {
 
-        initMocks(this);
+        openMocks(this);
     }
 
     @AfterMethod
     public void tearDown() throws Exception {
 
-    }
-
-    @ObjectFactory
-    public IObjectFactory getObjectFactory() {
-
-        return new org.powermock.modules.testng.PowerMockObjectFactory();
     }
 
 
@@ -70,8 +60,7 @@ public class RegisterServiceComponentsTest {
                 serviceName[0] = resourceService.getClass().getName();
                 return null;
             }
-        }).when(bundleContext).registerService(anyString(), any(RegisterServiceComponents.class),
-                any(Dictionary.class));
+        }).when(bundleContext).registerService(anyString(), any(), any());
 
         RegisterServiceComponents registerServiceComponents = new RegisterServiceComponents();
         registerServiceComponents.activate(bundleContext);

--- a/components/org.wso2.carbon.identity.oauth.uma.xacml.extension/pom.xml
+++ b/components/org.wso2.carbon.identity.oauth.uma.xacml.extension/pom.xml
@@ -58,10 +58,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.felix</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -78,8 +78,8 @@
                 <inherited>true</inherited>
                 <configuration>
                     <encoding>UTF-8</encoding>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>21</source>
+                    <target>21</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -170,17 +170,10 @@
                 <scope>test</scope>
                 <version>${jacoco.version}</version>
             </dependency>
-            <!-- https://mvnrepository.com/artifact/org.powermock/powermock-module-testng -->
             <dependency>
-                <groupId>org.powermock</groupId>
-                <artifactId>powermock-module-testng</artifactId>
-                <version>${powermock.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.powermock</groupId>
-                <artifactId>powermock-api-mockito</artifactId>
-                <version>${powermock.version}</version>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>${mockito.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -354,10 +347,10 @@
         <swagger-jaxrs.version>1.6.2</swagger-jaxrs.version>
 
         <!--Test Dependencies-->
-        <testng.version>6.9.10</testng.version>
-        <jacoco.version>0.7.9</jacoco.version>
-        <powermock.version>1.6.6</powermock.version>
-        <maven.surefire.plugin.version>2.18.1</maven.surefire.plugin.version>
+        <testng.version>7.10.1</testng.version>
+        <jacoco.version>0.8.12</jacoco.version>
+        <mockito.version>5.3.1</mockito.version>
+        <maven.surefire.plugin.version>3.1.2</maven.surefire.plugin.version>
         <h2database.version>2.2.220</h2database.version>
         <org.wso2.carbon.identity.testutil.version>5.10.25</org.wso2.carbon.identity.testutil.version>
 
@@ -379,8 +372,8 @@
         <apache.felix.scr.ds.annotations.version>1.2.4</apache.felix.scr.ds.annotations.version>
 
         <!--Maven Plugin Version-->
-        <maven.bundle.plugin.version>3.2.0</maven.bundle.plugin.version>
-        <maven.compiler.plugin.version>2.3.1</maven.compiler.plugin.version>
+        <maven.bundle.plugin.version>5.1.9</maven.bundle.plugin.version>
+        <maven.compiler.plugin.version>3.14.1</maven.compiler.plugin.version>
         <carbon.p2.plugin.version>1.5.3</carbon.p2.plugin.version>
 
         <!-- Commons -->


### PR DESCRIPTION
# Purpose

Migrate the repo from Java 8 to Java 21. This migration removes the deprecated PowerMock dependency and modernizes the project's test infrastructure to ensure compatibility with Java 21.

---

# Goals

- Build and run all modules successfully with Java 21.
- Replace PowerMock with Mockito 5's native static and constructor mocking APIs.
- Update Maven build plugins and test dependencies to Java 21 compatible versions.

---

# Approach

## Compiler & Build Plugin Updates

Updated the project's build plugins to versions compatible with Java 21.

| Component | Previous | Updated |
|-----------|----------|---------|
| `maven-compiler-plugin` | 2.3.1 (`source`/`target` = 1.8) | 3.14.1 (`source`/`target` = 21) |
| `maven-bundle-plugin` | 3.2.0 | 5.1.9 |
| `maven-war-plugin` | 2.2 | 3.3.2 |

---

## Test Dependency Migration

Removed the legacy PowerMock dependencies and upgraded the test stack.

| Dependency | Previous | Updated |
|-----------|----------|---------|
| PowerMock | `powermock-module-testng`, `powermock-api-mockito` | Removed |
| Mockito | 1.x | `mockito-core` 5.3.1 |
| TestNG | 6.9.10 | 7.10.1 |
| JaCoCo | 0.7.9 | 0.8.12 |
| Maven Surefire | 2.18.1 | 3.1.2 |

---

## Test Code Migration (PowerMock → Mockito 5)

The unit tests were migrated to Mockito 5's native APIs.

| PowerMock Pattern | Mockito 5 Replacement |
|-------------------|-----------------------|
| `@PrepareForTest` + `PowerMockObjectFactory` | Removed; standard Mockito initialization |
| `PowerMockito.mockStatic(X.class)` | `Mockito.mockStatic(X.class)` using `try-with-resources` |
| `PowerMockito.whenNew(X.class).withAnyArguments().thenReturn(mock)` | `Mockito.mockConstruction(X.class, (mock, ctx) -> ...)` |
| `import static org.mockito.Matchers.*` | `import static org.mockito.ArgumentMatchers.*` |
| `MockitoAnnotations.initMocks(this)` | `MockitoAnnotations.openMocks(this)` |
| `object-factory="org.powermock.modules.testng.PowerMockObjectFactory"` | Removed from `testng.xml` |

---

# Automation Tests

All existing unit tests were migrated and continue to pass.

No test scenarios were removed; the original test coverage has been preserved under Mockito 5.

### Permission Service

- `PermissionServiceImplTest`
- `PermissionTicketDAOTest`
- `PermissionServiceComponentTest`

### Resource Service

- `ResourceServiceImplTest`
- `ResourceDAOTest`
- `RegisterServiceComponentsTest`

### REST API

- `PermissionApiServiceImplTest`
- `ResourceRegistrationApiServiceImplTest`
- `ResourceRegistrationApiServiceImplExceptionTest`